### PR TITLE
Use BottomSheetModalProps instead of BottomSheetProps as navigation options

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ const BottomSheet = createBottomSheetNavigator();
   <BottomSheet.Screen
     name="secondSheet"
     component={SecondSheetComponent}
-    // Can pass any prop from @gorhom/bottom-sheet
+    // Can pass any prop from @gorhom/bottom-sheet's BottomSheetModal
     options={{ snapPoints: [200, "100%"], index: 1 }}
   />
 </BottomSheet.Navigator>;
@@ -61,7 +61,7 @@ Defaults to `['66%']`.
 
 #### Other options
 
-Most props from bottom sheet are exposed as navigation options. See the [@gorhom/bottom-sheet website](https://gorhom.github.io/react-native-bottom-sheet/props) for full documentation.
+Most props from `BottomSheetModal` are exposed as navigation options. See the [@gorhom/bottom-sheet website](https://gorhom.github.io/react-native-bottom-sheet/modal/props) for full documentation.
 
 ### Navigation helpers
 

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -1,4 +1,4 @@
-import type { BottomSheetProps } from '@gorhom/bottom-sheet';
+import type { BottomSheetModalProps } from '@gorhom/bottom-sheet';
 import type {
   DefaultNavigatorOptions,
   Descriptor,
@@ -64,7 +64,7 @@ export type BottomSheetNavigationHelpers = NavigationHelpers<
 export type BottomSheetNavigationConfig = {};
 
 export type BottomSheetNavigationOptions = Omit<
-  BottomSheetProps,
+  BottomSheetModalProps,
   // Remove some props that aren't useful as navigation options.
   | 'containerHeight'
   | 'snapPoints'


### PR DESCRIPTION
Hey there, thanks for this library, it has been very useful!

I came across an issue that this PR attempts to fix. I wanted to use the `stackBehavior` option but it is added by `BottomSheetModalProps`. Since this library's `BottomSheetView` component does use the `BottomSheetModal` abstraction from `@gorhom/bottom-sheet`, I believe this library's props should also inherit the same props.

I think this might also fix this issue:
- https://github.com/th3rdwave/react-navigation-bottom-sheet/issues/5

Thank you!