### PR TITLE
fix: Prevents Extra Screen Render when navigation index has not changed

### DIFF
--- a/src/BottomSheetView.tsx
+++ b/src/BottomSheetView.tsx
@@ -65,8 +65,9 @@ function BottomSheetModalScreen({
 
   const onChange = React.useCallback(
     (newIndex: number) => {
+      const currentIndex = lastIndexRef.current;
       lastIndexRef.current = newIndex;
-      if (newIndex >= 0) {
+      if (newIndex >= 0 && newIndex !== currentIndex) {
         navigation.snapTo(newIndex);
       }
     },


### PR DESCRIPTION
# What does this PR do?

* This PR prevents the bottomsheet screen from being rendered a second time if the navigation index has not changed.

# How should this be manually tested?

* Add a console.log to any of your bottomsheet screens to track how many times the screen is rendered.
* On the main branch, navigate to your bottomsheet screen, and you'll notice that the screen is being rendered twice, which inadvertently/unexpectedly dismisses the keyboard and clears the text input(s).
* On this PR branch, you'll notice that the screen is only being rendered once (unless the navigation index changes and it needs to render a second time).

# Background Information

* This issue was discovered when using `@gorhom/bottom-sheet` and I was able to trace the issue back to the [react-navigation-bottom-sheet](https://github.com/th3rdwave/react-navigation-bottom-sheet) repository and fix it here in this PR.

# ❌ Before Video
BEFORE — Renders twice. The second render happens ~1 second after mount. The second render causes the entire screen to be re-rendered, which inadvertently/unexpectedly dismisses the keyboard and clears the text input(s).

https://github.com/user-attachments/assets/0d245b00-ed8d-439c-be25-6cf5e92d871f

# ✅ After Video
AFTER — Only renders when needed!

https://github.com/user-attachments/assets/e26f5618-72cd-4422-a35f-e1b85fb4df29

